### PR TITLE
Use `github.sha` as the default `head` commit for `pull_request`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ Or the previous branch head for `push` event.
 
 Head commit/branch to compare.
 
-**Default**: `${{ github.event.pull_request.merge_commit_sha || github.sha }}` -
-the "current commit" or merge commit for pull requests.
+**Default**: `${{ github.event.pull_request.merge_commit_sha }}` for `pull_request_target` event,
+otherwise `${{ github.sha }}` - the "current commit" or merge commit for pull requests.
 
 > [!NOTE]
 > There is a special case for `pull_request_target` event -
-> because `${{ github.sha }}` will be the head of the default branch for `pull_request_target`.
+> because `${{ github.sha }}` will be the head of the base branch for `pull_request_target`.
 
 ### `github-token`
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
 
   head:
     description: Head commit/branch
-    default: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+    default: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
     required: true
 
   github-token:


### PR DESCRIPTION
It seems that `github.event.pull_request.merge_commit_sha` can be stale